### PR TITLE
first successful setup.py

### DIFF
--- a/src/civilite/__init__.py
+++ b/src/civilite/__init__.py
@@ -1,0 +1,8 @@
+'''metadata for civilite'''
+import civilite._meta as meta
+
+__author__ = meta.__author__
+__author_email__ = meta.__author_email__
+__license__ = meta.__license__
+__url__ = meta.__url__
+__version__ = meta.__version__

--- a/src/civilite/_meta.py
+++ b/src/civilite/_meta.py
@@ -3,7 +3,7 @@ Package constants
 """
 
 __author__ = "Andrey Vasilik"
-__author_email__ = "noreply@github.com"
+__author_email__ = "basil96@users.noreply.github.com"
 __license__ = "MIT"
 __url__ = "https://github.com/basil96/civilite"
 __version__ = "1.0.2"

--- a/src/civilite/_meta.py
+++ b/src/civilite/_meta.py
@@ -1,0 +1,9 @@
+"""
+Package constants
+"""
+
+__author__ = "Andrey Vasilik"
+__author_email__ = "noreply@github.com"
+__license__ = "MIT"
+__url__ = "https://github.com/basil96/civilite"
+__version__ = "1.0.2"

--- a/src/civilite/schedule.py
+++ b/src/civilite/schedule.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ''' Scheduling module for civilite '''
-__version__ = '1.0.1'
+ 
 
 # Builtins
 import calendar
@@ -12,6 +12,10 @@ from typing import Dict, Optional, Tuple
 import pytz
 from astral import Observer, SunDirection
 from astral.sun import twilight
+#self
+import civilite._meta as meta
+
+__version__ = meta.__version__
 
 # Event definitions for describing tasks on the Intermatic astro time clock
 # Assumptions:

--- a/src/scripts/make_calendar_pdf.py
+++ b/src/scripts/make_calendar_pdf.py
@@ -2,7 +2,6 @@
 ''' Client for creating a nicely formatted PDF calendar for a
     specified year or the current year (default).
 '''
-__version__ = '1.0.1'
 
 # builtins
 import calendar
@@ -15,8 +14,11 @@ from reportlab.lib.pagesizes import inch, letter
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle
 
 # custom
+import civilite._meta as meta
 from civilite.schedule import (EVENT_TYPES, EVT_FIXED, EVT_NEVER_ON,
                                EVT_SUNSET, createEvents, getCurrentSchedule)
+
+__version__ = meta.__version__
 
 THIS_YEAR = date.today().year
 if len(sys.argv) > 1:

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+"""Setup script for packaging civilite.
+
+To build a package for distribution:
+    python setup.py sdist
+and upload it to the PyPI with:
+    python setup.py upload
+
+Install a link for development work (from ./src directory)
+    pip install -e .
+
+"""
+
+import os
+
+from setuptools import setup, find_packages
+
+here = os.path.abspath(os.path.dirname(__file__))
+try:
+    with open(os.path.join(here, 'README.md')) as f:
+        README = f.read()
+except IOError:
+    README = ''
+
+from importlib.util import module_from_spec, spec_from_file_location
+spec = spec_from_file_location("meta", "./civilite/_meta.py") 
+meta = module_from_spec(spec)
+spec.loader.exec_module(meta)
+__version__ = meta.__version__
+__author__ = meta.__author__
+__author_email__ = meta.__author_email__
+__license__ = meta.__license__
+__url__ = meta.__url__
+
+
+setup(
+    name='civilite',
+    packages=find_packages(
+        exclude=["*.tests", "test_.*", "tests"]
+        ),
+    package_dir={},
+    # metadata
+    version=__version__,
+    description="A Python Library for managing outdoor lighting when building occupancy and available daylight must be considered.",
+    long_description=README,
+    author=__author__,
+    author_email=__author_email__,
+    url=__url__,
+    license=__license__,
+    python_requires=">=3.6, ",
+    install_requires=[
+        'astral==2.1',
+        'pytz==2019.3',
+        'reportlab==3.5.42',
+    ],
+    project_urls={
+        'Documentation': '',
+        'Source': __url__,
+        'Issues': 'https://github.com/basil96/civilite/issues',
+    },
+    classifiers=[
+                 'Operating System :: Microsoft :: Windows',
+                 'License :: OSI Approved :: MIT License',
+                 'Programming Language :: Python',
+                 'Programming Language :: Python :: 3.7'
+                 ],
+    )

--- a/src/setup.py
+++ b/src/setup.py
@@ -65,6 +65,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX :: Linux',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',

--- a/src/setup.py
+++ b/src/setup.py
@@ -13,25 +13,26 @@ Install a link for development work (from ./src directory)
 """
 
 import os
-
+from importlib.util import module_from_spec, spec_from_file_location
 from setuptools import setup, find_packages
 
-here = os.path.abspath(os.path.dirname(__file__))
+SPEC = spec_from_file_location("meta", "./civilite/_meta.py")
+METADATA = module_from_spec(SPEC)
+SPEC.loader.exec_module(METADATA)
+__version__ = METADATA.__version__
+__author__ = METADATA.__author__
+__author_email__ = METADATA.__author_email__
+__license__ = METADATA.__license__
+__url__ = METADATA.__url__
+
+ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 try:
-    with open(os.path.join(here, 'README.md')) as f:
+    with open(os.path.join(ROOT_PATH, 'README.md')) as f:
         README = f.read()
 except IOError:
     README = ''
 
-from importlib.util import module_from_spec, spec_from_file_location
-spec = spec_from_file_location("meta", "./civilite/_meta.py") 
-meta = module_from_spec(spec)
-spec.loader.exec_module(meta)
-__version__ = meta.__version__
-__author__ = meta.__author__
-__author_email__ = meta.__author_email__
-__license__ = meta.__license__
-__url__ = meta.__url__
+
 
 
 setup(
@@ -42,7 +43,8 @@ setup(
     package_dir={},
     # metadata
     version=__version__,
-    description="A Python Library for managing outdoor lighting when building occupancy and available daylight must be considered.",
+    description="A Python Library for managing outdoor lighting when building occupancy and"
+                " available daylight must be considered.",
     long_description=README,
     author=__author__,
     author_email=__author_email__,
@@ -60,9 +62,12 @@ setup(
         'Issues': 'https://github.com/basil96/civilite/issues',
     },
     classifiers=[
-                 'Operating System :: Microsoft :: Windows',
-                 'License :: OSI Approved :: MIT License',
-                 'Programming Language :: Python',
-                 'Programming Language :: Python :: 3.7'
-                 ],
-    )
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Operating System :: Microsoft :: Windows',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
+    ],
+)


### PR DESCRIPTION
Created a setup.py in the .src directory. 

Verified this works by creating a new virtualenv and then activating. change to ./src and then run 
`pip install -e .`
`>C:/venvs/civilite-test/scripts/activate.bat

(civilite-test) \civilite>cd src

(civilite-test) \civilite\src>pip install -e .
Obtaining file:///C:/Users/sean/Documents/Git%20Repos/civilite/src
Collecting astral==2.1 (from civilite==1.0.2)
  Using cached https://files.pythonhosted.org/packages/53/21/999d5727cfe701b9421be6e2d15fca42a8c33210a06888bf0d7d38cb9c3b/astral-2.1-py3-none-any.whl
Collecting pytz==2019.3 (from civilite==1.0.2)
  Using cached https://files.pythonhosted.org/packages/e7/f9/f0b53f88060247251bf481fa6ea62cd0d25bf1b11a87888e53ce5b7c8ad2/pytz-2019.3-py2.py3-none-any.whl
Collecting reportlab==3.5.42 (from civilite==1.0.2)
  Using cached https://files.pythonhosted.org/packages/40/07/03856102c3f828336f23b93c7959e9ea88a62b1b9803373075ce09729782/reportlab-3.5.42-cp37-cp37m-win_amd64.whl
Collecting pillow>=4.0.0 (from reportlab==3.5.42->civilite==1.0.2)
  Using cached https://files.pythonhosted.org/packages/f7/2a/e4efd9f31ed11af9954b2e0470ed346735700b4492743c0480c172420ca3/Pillow-7.1.2-cp37-cp37m-win_amd64.whl
Installing collected packages: pytz, astral, pillow, reportlab, civilite
  Running setup.py develop for civilite
Successfully installed astral-2.1 civilite pillow-7.1.2 pytz-2019.3 reportlab-3.5.42
You are using pip version 19.0.3, however version 20.1 is available.
You should consider upgrading via the 'python -m pip install --upgrade pip' command.`

This creates an editable version. 
then 

`(civilite-test) \civilite\src>.\scripts\make_calendar_pdf.py
Creating the lighting control schedule for year 2020
Schedule sunsets_2020.csv created.
Creating template..
Creating table...
Calendar lighting_calendar_2020.pdf created.`